### PR TITLE
docs: add homepage to Akash Network organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ Comprehensive documentation is available at [docs.akash.network](https://docs.ak
 Join our vibrant community and stay connected:
 
 - **Discord**: [discord.akash.network](https://discord.akash.network) - Real-time chat and support
-- **Forum**: [forum.akash.network](https://forum.akash.network) - In-depth discussions and proposals
 - **Twitter**: [@akashnet_](https://twitter.com/akashnet_) - Latest news and updates
-- **Telegram**: [t.me/AkashNW](https://t.me/AkashNW) - Community chat
 - **Reddit**: [r/akashnetwork](https://reddit.com/r/akashnetwork) - Community discussions
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Akash Network
+
+[![Website](https://img.shields.io/badge/Website-akash.network-blue)](https://akash.network)
+[![Documentation](https://img.shields.io/badge/Docs-docs.akash.network-green)](https://docs.akash.network)
+[![Discord](https://img.shields.io/discord/747885925232672829?label=Discord&logo=discord)](https://discord.akash.network)
+[![Twitter](https://img.shields.io/twitter/follow/akashnet_?style=social)](https://twitter.com/akashnet_)
+
+[Akash Network](https://akash.network) is the world's first decentralized cloud computing marketplace that enables anyone to buy and sell computing resources securely and efficiently. Built on the Cosmos SDK, Akash provides a permissionless, sovereign, and open cloud where developers can deploy applications at a fraction of the cost of traditional cloud providers.
+
+## 🏗️ Project Structure
+
+The Akash Network ecosystem consists of several key repositories:
+
+### Core Infrastructure
+- **[node](https://github.com/akash-network/node)** - The Akash blockchain node implementation
+- **[provider](https://github.com/akash-network/provider)** - Akash Provider daemon for resource providers
+- **[support](https://github.com/akash-network/support)** - Core protocol support and issue tracking
+
+### Clients
+- **[console](https://github.com/akash-network/console)** - Web-based deployment interface
+- **[terraform-provider-akash](https://github.com/akash-network/terraform-provider-akash)** - Akash Terraform provider
+
+### Developer Tools
+- **[chain-sdk](https://github.com/akash-network/chain-sdk)** - Akash Network SDK
+
+### Documentation & Community
+- **[docs](https://github.com/akash-network/docs)** - Official documentation source
+- **[website](https://github.com/akash-network/website)** - Official website source code
+- **[community](https://github.com/akash-network/community)** - Community resources and governance
+- **[awesome-akash](https://github.com/akash-network/awesome-akash)** - Curated list of Akash resources
+
+## 🚀 Getting Started
+
+### For Developers
+1. **Deploy an Application**: Use the [Akash Console](https://console.akash.network) for a user-friendly deployment experience
+2. **CLI Deployment**: Follow our [CLI deployment guide](https://docs.akash.network/guides/deploy)
+
+### For Providers
+1. **Become a Provider**: Set up your infrastructure to earn AKT by providing computing resources
+2. **Provider Setup Guide**: Follow the [provider documentation](https://docs.akash.network/providers)
+
+### For Contributors
+1. **Find an Issue**: Browse open issues across our console and support repositories
+2. **Read Contributing Guidelines**: Check each repository's `CONTRIBUTING.md`
+3. **Join the Community**: Connect with other contributors on [Discord](https://discord.akash.network)
+
+## 📚 Documentation
+
+Comprehensive documentation is available at [docs.akash.network](https://docs.akash.network), including:
+
+- **Deployment Guides**: Step-by-step tutorials for deploying applications
+- **Provider Guides**: Complete setup and maintenance instructions for providers
+- **API Reference**: Detailed API documentation for developers
+- **Network Information**: Blockchain specifications and network parameters
+
+## 🌐 Community
+
+Join our vibrant community and stay connected:
+
+- **Discord**: [discord.akash.network](https://discord.akash.network) - Real-time chat and support
+- **Forum**: [forum.akash.network](https://forum.akash.network) - In-depth discussions and proposals
+- **Twitter**: [@akashnet_](https://twitter.com/akashnet_) - Latest news and updates
+- **Telegram**: [t.me/AkashNW](https://t.me/AkashNW) - Community chat
+- **Reddit**: [r/akashnetwork](https://reddit.com/r/akashnetwork) - Community discussions
+
+## 🤝 Contributing
+
+We welcome contributions from developers of all skill levels! Here's how you can get involved:
+
+### Reporting Issues
+- **Console Issues**: Report in the [console repository](https://github.com/akash-network/console/issues)
+- **Core Protocol Issues**: Report in the [support repository](https://github.com/akash-network/support/issues)
+
+Please read the `CONTRIBUTING.md` file in each repository for specific guidelines.
+
+## 📊 Network Stats
+
+- **Akash Statistics**: View current statistics at [stats.akash.network](https://stats.akash.network)
+
+## 🛡️ Code of Conduct
+
+We are committed to fostering a welcoming and inclusive community. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand our community guidelines.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Discord](https://img.shields.io/discord/747885925232672829?label=Discord&logo=discord)](https://discord.akash.network)
 [![Twitter](https://img.shields.io/twitter/follow/akashnet_?style=social)](https://twitter.com/akashnet_)
 
-[Akash Network](https://akash.network) is the world's first decentralized cloud computing marketplace that enables anyone to buy and sell computing resources securely and efficiently. Built on the Cosmos SDK, Akash provides a permissionless, sovereign, and open cloud where developers can deploy applications at a fraction of the cost of traditional cloud providers.
-
+[Akash Network](https://akash.network) is a secure, transparent, and decentralized cloud computing marketplace that connects those who need computing resources (tenants) with those that have computing capacity to lease (providers).
 ## 🏗️ Project Structure
 
 The Akash Network ecosystem consists of several key repositories:


### PR DESCRIPTION
add homepage to the Akash Network organization to help users navigate the repositories and the network